### PR TITLE
Fix EXISTS and DEL bug for sharding and consensus situation

### DIFF
--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -540,8 +540,7 @@ void Cmd::Execute() {
     ProcessFlushAllCmd();
   } else if (name_ == kCmdNameInfo || name_ == kCmdNameConfig) {
     ProcessDoNotSpecifyPartitionCmd();
-  } else if (is_single_partition() ||
-      (g_pika_conf->classic_mode() && g_pika_conf->consensus_level() == 0)) {
+  } else if (is_single_partition() || g_pika_conf->classic_mode()) {
     ProcessSinglePartitionCmd();
   } else if (is_multi_partition()) {
     ProcessMultiPartitionCmd();
@@ -649,8 +648,7 @@ void Cmd::InternalProcessCommand(std::shared_ptr<Partition> partition,
     std::shared_ptr<SyncMasterPartition> sync_partition, const HintKeys& hint_keys) {
   slash::lock::MultiRecordLock record_lock(partition->LockMgr());
   if (is_write()) {
-    if (!hint_keys.empty() && is_multi_partition() &&
-     !g_pika_conf->classic_mode() && g_pika_conf->consensus_level() == 0) {
+    if (!hint_keys.empty() && is_multi_partition() && !g_pika_conf->classic_mode()) {
       record_lock.Lock(hint_keys.keys);
     } else {
       record_lock.Lock(current_key());
@@ -662,8 +660,7 @@ void Cmd::InternalProcessCommand(std::shared_ptr<Partition> partition,
   DoBinlog(sync_partition);
 
   if (is_write()) {
-    if (!hint_keys.empty() && is_multi_partition() &&
-     !g_pika_conf->classic_mode() && g_pika_conf->consensus_level() == 0) {
+    if (!hint_keys.empty() && is_multi_partition() && !g_pika_conf->classic_mode()) {
       record_lock.Unlock(hint_keys.keys);
     } else {
       record_lock.Unlock(current_key());
@@ -676,8 +673,7 @@ void Cmd::DoCommand(std::shared_ptr<Partition> partition, const HintKeys& hint_k
     partition->DbRWLockReader();
   }
 
-  if (!hint_keys.empty() && is_multi_partition() &&
-     !g_pika_conf->classic_mode() && g_pika_conf->consensus_level() == 0) {
+  if (!hint_keys.empty() && is_multi_partition() && !g_pika_conf->classic_mode()) {
     Split(partition, hint_keys);
   } else {
     Do(partition);
@@ -731,7 +727,10 @@ void Cmd::ProcessMultiPartitionCmd() {
   std::shared_ptr<Table> table = g_pika_server->GetTable(table_name_);
   if (!table) {
     res_.SetRes(CmdRes::kErrOther, "Table not found");
+    return;
   }
+
+  CmdStage current_stage = stage_;
   for (auto& key : cur_key) {
     LOG(INFO) << "process key: "<< key;
     // in sharding mode we select partition by key
@@ -765,7 +764,9 @@ void Cmd::ProcessMultiPartitionCmd() {
       return;
     }
   }
-  Merge();
+  if (current_stage == kNone || current_stage == kExecuteStage) {
+    Merge();
+  }
 }
 
 void Cmd::ProcessDoNotSpecifyPartitionCmd() {


### PR DESCRIPTION
  In sharding and consensus situation, SXISTS command will call Do instead of Split,
this lead response message append twice in Do and Merge.
  For DEL command, this is a write command, and for consensus case, pika will call
Execute twice for DoBinlog and DoCommand respectively, and cause Merge called double.