### PR TITLE
exchange the LOG locations of backup finished and failed

### DIFF
--- a/src/pika_partition.cc
+++ b/src/pika_partition.cc
@@ -382,12 +382,13 @@ bool Partition::RunBgsaveEngine() {
 
   // Backup to tmp dir
   rocksdb::Status s = bgsave_engine_->CreateNewBackup(info.path);
-  LOG(INFO) << partition_name_ << " create new backup finished.";
 
   if (!s.ok()) {
     LOG(WARNING) << partition_name_ << " create new backup failed :" << s.ToString();
     return false;
   }
+  LOG(INFO) << partition_name_ << " create new backup finished.";
+
   return true;
 }
 


### PR DESCRIPTION
Whether the backup succeeds or not, it will print "finshed" when I start backup command.
I had exchanged the positions of the "finished" and "failed" codes.
Thanks.