### PR TITLE
fix command info keyspace off

### DIFF
--- a/src/pika_partition.cc
+++ b/src/pika_partition.cc
@@ -540,11 +540,11 @@ Status Partition::GetKeyNum(std::vector<blackwidow::KeyInfo>* key_info) {
   key_scan_info_.duration = -2;   // duration -2 mean the task in waiting status,
                                   // has not been scheduled for exec
   rocksdb::Status s = db_->GetKeyNum(key_info);
+  key_scan_info_.key_scaning_ = false;
   if (!s.ok()) {
     return Status::Corruption(s.ToString());
   }
   key_scan_info_.key_infos = *key_info;
   key_scan_info_.duration = time(NULL) - key_scan_info_.start_time;
-  key_scan_info_.key_scaning_ = false;
   return Status::OK();
 }

--- a/src/pika_table.cc
+++ b/src/pika_table.cc
@@ -190,6 +190,9 @@ void Table::RunKeyScan() {
 void Table::StopKeyScan() {
   slash::RWLock rwl(&partitions_rw_, false);
   slash::MutexLock ml(&key_scan_protector_);
+  if (!key_scan_info_.key_scaning_) {
+    return;
+  }
   for (const auto& item : partitions_) {
     item.second->db()->StopScanKeyNum();
   }


### PR DESCRIPTION
最近发现info keyspace off命令有两个小bug：
* 在使用命令info keyspace 1命令遍历db时，使用info keyspace off命令中断遍历过程会导致变量`key_scan_info_.key_scaning_`永远不能被改为false，导致之后再执行info keyspace 1命令无法重新遍历db。

* 在没有遍历任务进行的状态下，直接使用info keyspace off命令，仍然会将变量`scan_keynum_exit_`设置为true，从而导致下一次执行info keyspace 1命令的遍历过程直接被中断