### PR TITLE
EXPORTER 监控调用info all 命令慢问题待解决

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -691,6 +691,7 @@ void InfoCmd::Do(std::shared_ptr<Partition> partition) {
       info.append("\r\n");
       InfoKeyspace(info);
       break;
+    // TODO EXPORTER监控调用info all 命令慢问题待解决
     case kInfoAll:
       InfoServer(info);
       info.append("\r\n");


### PR DESCRIPTION
PIKA3.2.8版本在exporter调用pika的info all命令时,会有大量的info all打出来的慢日志,pika单节点数据量在150G左右,请求tps 50k/s左右,info all有时时间达到100ms左右