### PR TITLE
add Rocksdb to read parameters from the configuration file

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -146,6 +146,9 @@ max-bytes-for-level-multiplier : 10
 # share-block-cache: no
 # whether or not index and filter blocks is stored in block cache
 # cache-index-and-filter-blocks: no
+# pin_l0_filter_and_index_blocks_in_cache [yes | no]
+# When `cache-index-and-filter-blocks` is enabled, `pin_l0_filter_and_index_blocks_in_cache` is suggested to be enabled
+# pin_l0_filter_and_index_blocks_in_cache : no
 # when set to yes, bloomfilter of the last level will not be built
 # optimize-filters-for-hits: no
 # https://github.com/facebook/rocksdb/wiki/Leveled-Compaction#levels-target-size

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -75,6 +75,7 @@ class PikaConf : public slash::BaseConf {
   int64_t block_cache()                             { RWLock l(&rwlock_, false); return block_cache_; }
   bool share_block_cache()                          { RWLock l(&rwlock_, false); return share_block_cache_; }
   bool cache_index_and_filter_blocks()              { RWLock l(&rwlock_, false); return cache_index_and_filter_blocks_; }
+  bool pin_l0_filter_and_index_blocks_in_cache()    { RWLock l(&rwlock_, false); return pin_l0_filter_and_index_blocks_in_cache_; }
   bool optimize_filters_for_hits()                  { RWLock l(&rwlock_, false); return optimize_filters_for_hits_; }
   bool level_compaction_dynamic_level_bytes()       { RWLock l(&rwlock_, false); return level_compaction_dynamic_level_bytes_; }
   int expire_logs_nums()                            { RWLock l(&rwlock_, false); return expire_logs_nums_; }
@@ -343,6 +344,7 @@ class PikaConf : public slash::BaseConf {
   int64_t block_cache_;
   bool share_block_cache_;
   bool cache_index_and_filter_blocks_;
+  bool pin_l0_filter_and_index_blocks_in_cache_;
   bool optimize_filters_for_hits_;
   bool level_compaction_dynamic_level_bytes_;
   std::atomic<int> sync_window_size_;

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -456,6 +456,10 @@ int PikaConf::Load()
   GetConfStr("cache-index-and-filter-blocks", &ciafb);
   cache_index_and_filter_blocks_ = (ciafb == "yes") ? true : false;
 
+  std::string plfaibic;
+  GetConfStr("pin_l0_filter_and_index_blocks_in_cache", &plfaibic);
+  pin_l0_filter_and_index_blocks_in_cache_ = (plfaibic == "yes") ? true : false;
+
   std::string offh;
   GetConfStr("optimize-filters-for-hits", &offh);
   optimize_filters_for_hits_ = (offh == "yes") ? true : false;

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1650,6 +1650,9 @@ void PikaServer::InitBlackwidowOptions() {
   bw_options_.block_cache_size = g_pika_conf->block_cache();
   bw_options_.share_block_cache = g_pika_conf->share_block_cache();
 
+  bw_options_.table_options.pin_l0_filter_and_index_blocks_in_cache =
+      g_pika_conf->pin_l0_filter_and_index_blocks_in_cache();
+
   if (bw_options_.block_cache_size == 0) {
     bw_options_.table_options.no_block_cache = true;
   } else if (bw_options_.share_block_cache) {


### PR DESCRIPTION
add rocksdb option `pin_l0_filter_and_index_blocks_in_cache` read from configuration file
加了一个 rocksdb 的配置项  `pin_l0_filter_and_index_blocks_in_cache`  能够从 配置文件中读取